### PR TITLE
Added missing 'use DateTime()'

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -16,6 +16,7 @@
 
 namespace WP_SQLite_DB {
 
+	use DateTime;
     use PDO;
     use PDOException;
 


### PR DESCRIPTION
I forgot to include `use DateTime()` right after namespace opening :facepalm: 